### PR TITLE
remove vercel crons

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,3 @@
 {
-    "crons": [
-      {
-        "path": "/api/hello",
-        "schedule": "*/14 * * * *"
-      }
-    ]
+    "crons": []
   }


### PR DESCRIPTION
removed crons cuz vercel needs you to pay to use crons. this is why deployment for this is failing.

so opted for this free service. called cron-job(dot)org. I'm currently running it with my account but leaving some documentation here so you can set it up yourself when needed. or ask gpt.

my settings, basically this service will hit the server API deployed on render so it stays alive:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/63de33ac-d4e8-4ec9-87d5-341ffbed0f83" />
